### PR TITLE
Fix bug when sort-by contains geo points

### DIFF
--- a/.changeset/dirty-mangos-tie.md
+++ b/.changeset/dirty-mangos-tie.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": patch
+---
+
+Fix bug where sort-by failed on geo_points

--- a/packages/instant-meilisearch/__tests__/sort.test.ts
+++ b/packages/instant-meilisearch/__tests__/sort.test.ts
@@ -66,14 +66,12 @@ describe('Sort browser test', () => {
   test('split one sorting rule', () => {
     const sortRules = splitSortString('_geoPoint(37.8153, -122.4784):asc')
 
-    console.log()
     expect(sortRules).toEqual(['_geoPoint(37.8153, -122.4784):asc'])
   })
 
   test.only('split no sorting rule', () => {
     const sortRules = splitSortString('')
 
-    console.log()
     expect(sortRules).toEqual([])
   })
 })

--- a/packages/instant-meilisearch/__tests__/sort.test.ts
+++ b/packages/instant-meilisearch/__tests__/sort.test.ts
@@ -5,6 +5,8 @@ import {
   meilisearchClient,
 } from './assets/utils'
 
+import { splitSortString } from '../src/contexts/sort-context'
+
 describe('Sort browser test', () => {
   beforeAll(async () => {
     const deleteTask = await meilisearchClient.deleteIndex('movies')
@@ -47,5 +49,31 @@ describe('Sort browser test', () => {
 
     const hits = response.results[0].hits
     expect(hits.length).toBe(1)
+  })
+
+  test('split multiple sorting rules', () => {
+    const sortRules = splitSortString(
+      '_geoPoint(37.8153, -122.4784):asc,title:asc,description:desc'
+    )
+
+    expect(sortRules).toEqual([
+      '_geoPoint(37.8153, -122.4784):asc',
+      'title:asc',
+      'description:desc',
+    ])
+  })
+
+  test('split one sorting rule', () => {
+    const sortRules = splitSortString('_geoPoint(37.8153, -122.4784):asc')
+
+    console.log()
+    expect(sortRules).toEqual(['_geoPoint(37.8153, -122.4784):asc'])
+  })
+
+  test.only('split no sorting rule', () => {
+    const sortRules = splitSortString('')
+
+    console.log()
+    expect(sortRules).toEqual([])
   })
 })

--- a/packages/instant-meilisearch/src/contexts/sort-context.ts
+++ b/packages/instant-meilisearch/src/contexts/sort-context.ts
@@ -1,10 +1,22 @@
 /**
- * @param {string} rawSort
+ * Split sort string into an array.
+ *
+ * Example:
+ * '_geoPoint(37.8153, -122.4784):asc,title:asc,description:desc'
+ *
+ * becomes:
+ * [
+ * '_geoPoint(37.8153, -122.4784):asc',
+ * 'title:asc',
+ * 'description:desc',
+ * ]
+ *
+ * @param {string} sortStr
  * @returns {string[]}
  */
-export function createSortState(rawSort: string): string[] {
-  return rawSort
-    .split(',')
-    .map((sort) => sort.trim())
-    .filter((sort) => !!sort)
+export function splitSortString(sortStr: string): string[] {
+  if (!sortStr) return []
+  const sortRules = sortStr.split(/,(?=\w+:(?:asc|desc))/)
+
+  return sortRules
 }


### PR DESCRIPTION
Fixes: #1159 

The old implementation did not take into account that a sorting rule could contain the `,` character and naively splited on that char.

Which resulted in 

```
"indexName:_geoPoint(37.8153, -122.4784):asc"
```

Being transformed into:
```
[
      "indexName:_geoPoint(37.8153",
      "-122.4784):asc"
 ]
```

Instead of splitting solely on `,`, we now split on a coma if it is prepended by `asc` or `desc`.