### PR TITLE
Update dependabot changing ignore list to allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - 'skip-changelog'
-      - 'dependencies'
+      - "skip-changelog"
+      - "dependencies"
     rebase-strategy: disabled
 
   - package-ecosystem: npm
@@ -20,20 +20,5 @@ updates:
       - dependencies
     versioning-strategy: increase
     rebase-strategy: disabled
-    ignore:
-      - dependency-name: "eslint*"
-      - dependency-name: "babel-eslint"
-      - dependency-name: "rollup*"
-      - dependency-name: "babel-jest"
-      - dependency-name: "@rollup/*"
-      - dependency-name: "@typescript-eslint/*"
-      - dependency-name: "cssnano"
-      - dependency-name: "*jest*"
-      - dependency-name: "*cypress*"
-      - dependency-name: "prettier*"
-      - dependency-name: "regenerator-runtime*"
-      - dependency-name: "shx*"
-      - dependency-name: "@vue/*"
-      - dependency-name: "concurrently"
-      - dependency-name: "@types/jest*"
-      - dependency-name: "@testing-library/*"
+    allow:
+      - dependency-name: meilisearch


### PR DESCRIPTION
To avoid being spammed with none-critical dependencies updates suggested by dependabot, we are changing from `ignore` to `allow` in the dependabot file. Ensuring we only update the critical dependencies.

```
- dependency-name: meilisearch
```

meilisearch is kept as it is the only one that is builded with the package. Updates of this library ensure that the library includes all new features provided by meilisearch-js.

