### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "skip-changelog"
       - "dependencies"
     rebase-strategy: disabled
 


### PR DESCRIPTION
We don't want to skip this information in the changelog anymore since only Meilisearch version can be updated