### PR TITLE
Escape filter backslashes and quotes

### DIFF
--- a/.changeset/three-pandas-chew.md
+++ b/.changeset/three-pandas-chew.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": patch
+---
+
+Fixes issue where backslashes ("\") and quotes (`"`) are not escaped in filters.

--- a/packages/instant-meilisearch/__tests__/assets/utils.ts
+++ b/packages/instant-meilisearch/__tests__/assets/utils.ts
@@ -25,6 +25,7 @@ const dataset = [
       name: 'One two',
     },
     nullField: null,
+    'escape_\\_"me"': 'escape \\"me too"',
   },
   {
     id: 5,

--- a/packages/instant-meilisearch/__tests__/assets/utils.ts
+++ b/packages/instant-meilisearch/__tests__/assets/utils.ts
@@ -25,7 +25,8 @@ const dataset = [
       name: 'One two',
     },
     nullField: null,
-    'escape_\\_"me"': 'escape \\"me too"',
+    'crazy_\\_"field"': 'real \\"crazy"',
+    numberField: 5,
   },
   {
     id: 5,
@@ -47,6 +48,7 @@ const dataset = [
       name: 'One two',
     },
     nullField: null,
+    numberField: 10,
   },
   {
     id: 6,
@@ -68,6 +70,7 @@ const dataset = [
       name: 'One two',
     },
     nullField: null,
+    numberField: 15,
   },
   {
     id: 11,
@@ -220,6 +223,8 @@ export type Movies = {
     name?: string
   }
   nullField?: null
+  'crazy_\\_"field"'?: string
+  numberField?: number
   _highlightResult?: Movies
 }
 

--- a/packages/instant-meilisearch/__tests__/filter.test.ts
+++ b/packages/instant-meilisearch/__tests__/filter.test.ts
@@ -11,43 +11,16 @@ describe('Instant Meilisearch Browser test', () => {
     await meilisearchClient.waitForTask(deleteTask.taskUid)
     await meilisearchClient
       .index('movies')
-      .updateFilterableAttributes(['genres', 'title'])
+      .updateFilterableAttributes([
+        'genres',
+        'title',
+        'release_date',
+        'escape_\\_"me"',
+      ])
     const documentsTask = await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
     await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
-  })
-
-  test('one string facet on filter without a query', async () => {
-    const response = await searchClient.search<Movies>([
-      {
-        indexName: 'movies',
-        params: {
-          query: '',
-          facetFilters: ['genres:Adventure'],
-        },
-      },
-    ])
-
-    const hits = response.results[0].hits
-    expect(hits.length).toEqual(1)
-    expect(hits[0].title).toEqual('Star Wars')
-  })
-
-  test('one facet on filter with a query', async () => {
-    const response = await searchClient.search<Movies>([
-      {
-        indexName: 'movies',
-        params: {
-          query: 'four',
-          facetFilters: ['genres:Crime'],
-        },
-      },
-    ])
-
-    const hits = response.results[0].hits
-    expect(hits.length).toEqual(2)
-    expect(hits[0].title).toEqual('Four Rooms')
   })
 
   test('one string facet on filter without a query', async () => {
@@ -173,5 +146,35 @@ describe('Instant Meilisearch Browser test', () => {
 
     const hits = response.results[0].hits
     expect(hits[0].title).toEqual('Ariel')
+  })
+
+  test('numeric filter', async () => {
+    const params = {
+      indexName: 'movies',
+      params: {
+        query: '',
+        numericFilters: 'release_date:593395200 TO 818467200',
+      },
+    }
+
+    const response = await searchClient.search<Movies>([params])
+
+    const hits = response.results[0].hits
+    expect(hits.length).toEqual(3)
+    expect(hits.map((v) => v.release_date).sort()).toEqual([
+      593395200, 750643200, 818467200,
+    ])
+  })
+
+  test('quotation marks and backslashes', () => {
+    const params = {
+      indexName: 'movies',
+      params: {
+        query: '',
+        facetFilters: 'escape_\\_"me":escape \\"me too"',
+      },
+    }
+
+    return expect(searchClient.search<Movies>([params])).resolves.toBeTruthy()
   })
 })

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
@@ -84,16 +84,8 @@ function transformFilters(
  * @param  {Filter} [filter]
  * @returns {Array|undefined}
  */
-function nonEmptyFilterToArray(
-  filter?: Filter
-): Array<string | string[]> | undefined {
-  return filter !== undefined && filter.length !== 0
-    ? // Filter is a string
-      typeof filter === 'string'
-      ? [filter]
-      : // Filter is either a one- or two-dimensional array of strings
-        filter
-    : undefined
+function filterToArray(filter?: Filter): Array<string | string[]> | undefined {
+  return typeof filter === 'string' ? [filter] : filter
 }
 
 /**
@@ -110,8 +102,8 @@ function mergeFilters(
   transformedNumericFilters?: Filter,
   transformedFacetFilters?: Filter
 ): Filter {
-  const adaptedNumericFilters = nonEmptyFilterToArray(transformedNumericFilters)
-  const adaptedFacetFilters = nonEmptyFilterToArray(transformedFacetFilters)
+  const adaptedNumericFilters = filterToArray(transformedNumericFilters)
+  const adaptedFacetFilters = filterToArray(transformedFacetFilters)
 
   const adaptedFilters: Filter = []
 

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
@@ -1,93 +1,155 @@
 import type { Filter, SearchContext } from '../../types'
 
+const filterEscapeRegExp = /([\\"])/g
+
+function getValueWithEscapedBackslashesAndQuotes(value: string): string {
+  return value.replaceAll(filterEscapeRegExp, '\\$1')
+}
+
 /**
- * Transform InstantSearch filter to Meilisearch compatible filter format.
+ * Transform InstantSearch [facet filter](https://www.algolia.com/doc/api-reference/api-parameters/facetFilters/)
+ * to Meilisearch compatible filter format.
  * Change sign from `:` to `=`
  * "facet:facetValue" becomes "facet=facetValue"
  *
  * Wrap both the facet and its facet value between quotes.
- * This avoid formating issues on facets containing multiple words.
+ * This avoids formatting issues on facets containing multiple words.
+ * Escape backslash \\ and quote " characters.
  *
  * 'My facet:My facet value' becomes '"My facet":"My facet value"'
  *
- * @param  {string} filter?
- * @returns {Filter}
+ * @param {string} filter
+ * @returns {string}
  */
-function transformFilter(filter: string): string {
-  return filter.replace(/(.*):(.*)/i, '"$1"="$2"')
+function transformFacetFilter(filter: string): string {
+  const escapedFilter = getValueWithEscapedBackslashesAndQuotes(filter)
+  const colonIndex = escapedFilter.indexOf(':')
+  const attribute = escapedFilter.slice(0, colonIndex)
+  const value = escapedFilter.slice(colonIndex + 1)
+  return `"${attribute}"="${value}"`
+}
+
+// Matches first occurrence of an operator
+const numericSplitRegExp = /(?<!(?:[<!>]?=|<|>|:).*)([<!>]?=|<|>|:)/
+
+/**
+ * Transform InstantSearch [numeric filter](https://www.algolia.com/doc/api-reference/api-parameters/numericFilters/)
+ * to Meilisearch compatible filter format.
+ *
+ * 'price:5.99 TO 100' becomes '"price" 5.99 TO 100'
+ *
+ * 'price = 5.99' becomes '"price"=5.99'
+ *
+ * Wrap the attribute between quotes.
+ * Escape backslash (\\) and quote (") characters.
+ *
+ * @param {string} filter
+ * @returns {string}
+ */
+function transformNumericFilter(filter: string): string {
+  // TODO: What if escape facet values is enabled?
+  //       https://github.com/algolia/instantsearch/blob/da701529ed325bb7a1d782e80cb994711e20d94a/packages/instantsearch.js/src/lib/utils/escapeFacetValue.ts#L13-L21
+  const [attribute, operator, value] = filter.split(numericSplitRegExp)
+  const escapedAttribute = getValueWithEscapedBackslashesAndQuotes(attribute)
+  return `"${escapedAttribute.trim()}"${
+    operator === ':' ? ' ' : operator
+  }${value.trim()}`
 }
 
 /**
- * Itterate over all filters.
+ * Iterate over all filters.
  * Return the filters in a Meilisearch compatible format.
+ * Can return empty string or empty array, but not an array of empty strings
+ * or empty arrays.
  *
- * @param  {SearchContext['facetFilters']} filters?
+ * @param  {(filter: string) => string} transformCallback
+ * @param  {SearchContext['facetFilters']} filters
  * @returns {Filter}
  */
-function transformFilters(filters?: SearchContext['facetFilters']): Filter {
-  if (typeof filters === 'string') {
-    return transformFilter(filters)
-  } else if (Array.isArray(filters))
-    return filters
-      .map((filter) => {
-        if (Array.isArray(filter))
-          return filter
-            .map((nestedFilter) => transformFilter(nestedFilter))
-            .filter((elem) => elem)
-        else {
-          return transformFilter(filter)
-        }
-      })
-      .filter((elem) => elem)
-  return []
+function transformFilters(
+  transformCallback: (filter: string) => string,
+  filters: NonNullable<SearchContext['facetFilters']>
+): Filter {
+  // Note on `Array.isArray`:
+  // https://github.com/microsoft/TypeScript/issues/17002
+  // Typescript has problems with readonly, which makes it undesirable in
+  // most situations, the crux of the issue being that `Array.isArray`
+  // will return true for mutable arrays as well as immutable ones. Since Instantsearch.js
+  // decided to use readonly, we have to type cast, while keeping as much of the type
+  // safety as possible.
+  return typeof filters === 'string'
+    ? transformCallback(filters)
+    : filters
+        .map((filter) =>
+          (<(value: readonly any[] | any) => value is readonly any[]>(
+            Array.isArray
+          ))(filter)
+            ? filter
+                .map((nestedFilter) => transformCallback(nestedFilter))
+                // TODO: Do these filters have any purpose? Can we actually get empty strings? Should we handle empty strings?
+                //       Maybe handling these should be the responsibility of instantsearch.js and/or the user and their input.
+                //       Instead of these empty filters quietly being swallowed, they might even get us an error message, and
+                //       we might know something is wrong?
+                .filter((elem) => elem !== '')
+            : transformCallback(filter)
+        )
+        // works on strings too, as they're somewhat of an array
+        .filter((elem) => elem.length !== 0)
 }
 
 /**
  * Return the filter in an array if it is a string
  * If filter is array, return without change.
  *
- * @param  {Filter} filter
- * @returns {Array}
+ * @param  {Filter} [filter]
+ * @returns {Array|undefined}
  */
-function filterToArray(filter: Filter): Array<string | string[]> {
-  // Filter is a string
-
-  if (filter === '') return []
-  else if (typeof filter === 'string') return [filter]
-  // Filter is either an array of strings, or an array of array of strings
-  return filter
+function nonEmptyFilterToArray(
+  filter?: Filter
+): Array<string | string[]> | undefined {
+  return filter !== undefined && filter.length !== 0
+    ? // Filter is a string
+      typeof filter === 'string'
+      ? [filter]
+      : // Filter is either a one- or two-dimensional array of strings
+        filter
+    : undefined
 }
 
 /**
- * Merge facetFilters, numericFilters and filters together.
+ * Merge filters, transformedNumericFilters and transformedFacetFilters
+ * together.
  *
- * @param  {Filter} facetFilters
- * @param  {Filter} numericFilters
  * @param  {string} filters
+ * @param  {Filter} transformedNumericFilters
+ * @param  {Filter} transformedFacetFilters
  * @returns {Filter}
  */
 function mergeFilters(
-  facetFilters: Filter,
-  numericFilters: Filter,
-  filters: string
+  filters?: string,
+  transformedNumericFilters?: Filter,
+  transformedFacetFilters?: Filter
 ): Filter {
-  const adaptedFilters = filters.trim()
-  const adaptedFacetFilters = filterToArray(facetFilters)
-  const adaptedNumericFilters = filterToArray(numericFilters)
+  // TODO: If we are trimming this, shouldn't we trim the other ones too?
+  const adaptedFilters = filters?.trim()
+  const adaptedNumericFilters = nonEmptyFilterToArray(transformedNumericFilters)
+  const adaptedFacetFilters = nonEmptyFilterToArray(transformedFacetFilters)
 
-  const adaptedFilter = [
-    ...adaptedFacetFilters,
-    ...adaptedNumericFilters,
-    adaptedFilters,
-  ]
+  const adaptedFilter: Filter = []
 
-  const cleanedFilters = adaptedFilter.filter((filter) => {
-    if (Array.isArray(filter)) {
-      return filter.length
-    }
-    return filter
-  })
-  return cleanedFilters
+  if (adaptedFilters !== undefined && adaptedFilters !== '') {
+    adaptedFilter.push(adaptedFilters)
+  }
+
+  if (adaptedNumericFilters !== undefined) {
+    adaptedFilter.push(...adaptedNumericFilters)
+  }
+
+  if (adaptedFacetFilters !== undefined) {
+    adaptedFilter.push(...adaptedFacetFilters)
+  }
+
+  return adaptedFilter
 }
 
 /**
@@ -104,12 +166,18 @@ export function adaptFilters(
   numericFilters: SearchContext['numericFilters'],
   facetFilters: SearchContext['facetFilters']
 ): Filter {
-  const transformedFilter = transformFilters(facetFilters || [])
-  const transformedNumericFilter = transformFilters(numericFilters || [])
+  const transformedNumericFilters =
+    numericFilters !== undefined
+      ? transformFilters(transformNumericFilter, numericFilters)
+      : numericFilters
+  const transformedFacetFilters =
+    facetFilters !== undefined
+      ? transformFilters(transformFacetFilter, facetFilters)
+      : facetFilters
 
   return mergeFilters(
-    transformedFilter,
-    transformedNumericFilter,
-    filters || ''
+    filters,
+    transformedNumericFilters,
+    transformedFacetFilters
   )
 }

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/filter-adapter.ts
@@ -3,7 +3,7 @@ import type { Filter, SearchContext } from '../../types'
 const filterEscapeRegExp = /([\\"])/g
 
 function getValueWithEscapedBackslashesAndQuotes(value: string): string {
-  return value.replaceAll(filterEscapeRegExp, '\\$1')
+  return value.replace(filterEscapeRegExp, '\\$1')
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1256

## What does this PR do?
- Fixes issue where backslashes ("\\") and quotes (`"`) are not escaped in filters
- Also numeric filter attributes are now always wrapped in quotes

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
