### PR TITLE
InstantMeilisearch: Enable hybrid search

### DIFF
--- a/.changeset/fluffy-waves-love.md
+++ b/.changeset/fluffy-waves-love.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": minor
+---
+
+Enable experimental hybrid search

--- a/packages/instant-meilisearch/README.md
+++ b/packages/instant-meilisearch/README.md
@@ -222,7 +222,8 @@ The following options can be overridden:
 [`showMatchesPosition`](https://www.meilisearch.com/docs/reference/api/search#show-matches-position),
 [`matchingStrategy`](https://www.meilisearch.com/docs/reference/api/search#matching-strategy),
 [`showRankingScore`](https://www.meilisearch.com/docs/reference/api/search#ranking-score),
-[`attributesToSearchOn`](https://www.meilisearch.com/docs/reference/api/search#customize-attributes-to-search-on-at-search-time).
+[`attributesToSearchOn`](https://www.meilisearch.com/docs/reference/api/search#customize-attributes-to-search-on-at-search-time),
+[`hybrid`](https://www.meilisearch.com/docs/learn/experimental/vector_search)
 
 ```js
 instantMeiliSearch(

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -79,7 +79,7 @@ describe('Parameters adapter', () => {
     )
   })
 
-  test('hybrid can be overriden in the search parameters', () => {
+  test('hybrid search configuration can be set via search parameters', () => {
     const hybridSearchConfig = {
       semanticRatio: 0,
       embedder: 'default',

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -78,6 +78,22 @@ describe('Parameters adapter', () => {
       meiliSearchParams.matchingStrategy
     )
   })
+
+  test('hybrid can be overriden in the search parameters', () => {
+    const hybridSearchConfig = {
+      semanticRatio: 0,
+      embedder: 'default',
+    }
+
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      meiliSearchParams: {
+        hybrid: hybridSearchConfig,
+      },
+    })
+
+    expect(searchParams.hybrid).toBe(hybridSearchConfig)
+  })
 })
 
 describe('Geo filter adapter', () => {

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -232,6 +232,12 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         meiliSearchParams.attributesToSearchOn = value
       }
     },
+    addHybridSearch() {
+      const value = overrideParams?.hybrid
+      if (value !== undefined) {
+        meiliSearchParams.hybrid = value
+      }
+    },
   }
 }
 
@@ -263,6 +269,7 @@ export function adaptSearchParams(
   meilisearchParams.addMatchingStrategy()
   meilisearchParams.addShowRankingScore()
   meilisearchParams.addAttributesToSearchOn()
+  meilisearchParams.addHybridSearch()
 
   return meilisearchParams.getParams()
 }

--- a/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
+++ b/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
@@ -79,9 +79,11 @@ export function instantMeiliSearch(
   const instantMeilisearchConfig = getInstantMeilisearchConfig(
     instantMeiliSearchOptions
   )
+
   return {
     setMeiliSearchParams: (params): void => {
       const { meiliSearchParams } = instantMeiliSearchOptions
+
       instantMeiliSearchOptions.meiliSearchParams =
         meiliSearchParams === undefined
           ? params

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -53,6 +53,7 @@ export type OverridableMeiliSearchSearchParameters = Pick<
   | 'matchingStrategy'
   | 'showRankingScore'
   | 'attributesToSearchOn'
+  | 'hybrid'
 >
 
 type BaseInstantMeiliSearchOptions = {


### PR DESCRIPTION
# Pull Request

Hi 👋 this PR enables using the [hybrid search](https://www.meilisearch.com/docs/learn/experimental/vector_search#vector-search-with-auto-embeddings) experimental API with `@meilisearch/instant-meilisearch`.

## Issue

Solves #1286 

## Proposed API

Allow users to pass a `hybrid` object in the `meiliSearchParams` object when creating an instantMeilisearch client.

```js
instantMeiliSearch(host, apiKey, {
  primaryKey: 'id',
  
  meiliSearchParams: {
    // other meilisearch params
    hybrid: {
      semanticRatio: 0.9,
      embedder: 'default',
    },
  },
})
```

Additionally, the `adaptSearchParams` function will now internally handle this `hybrid` object.

## What does this PR do?
- Add `hybrid` object as an overridable search parameter

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
