### PR TITLE
Remove node 14 and 16 from workflow

### DIFF
--- a/.changeset/beige-peaches-divide.md
+++ b/.changeset/beige-peaches-divide.md
@@ -1,5 +1,5 @@
 ---
-"@meilisearch/autocomplete-client": patch
+"@meilisearch/autocomplete-client": minor
 ---
 
 Remove node 14 and 16 from workflow

--- a/.changeset/beige-peaches-divide.md
+++ b/.changeset/beige-peaches-divide.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/autocomplete-client": patch
+---
+
+Remove node 14 and 16 from workflow

--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['18', '20']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['18', '20']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['18', '20']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v4

--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,8 @@
 status = [
   'style-check',
   'types-check',
-  'integration-tests (Node.js 14)',
-  'integration-tests (Node.js 16)',
   'integration-tests (Node.js 18)',
+  'integration-tests (Node.js 20)',
   'autocomplete-client end-to-end-tests',
   'instant-meilisearch end-to-end-tests',
 ]

--- a/packages/autocomplete-client/README.md
+++ b/packages/autocomplete-client/README.md
@@ -255,7 +255,7 @@ This package guarantees compatibility with [version v1.x of Meilisearch](https:/
 
 **Node / NPM versions**:
 
-- NodeJS >= 14 <= 18
+- NodeJS >= 18
 
 ## ⚙️ Development Workflow and Contributing
 


### PR DESCRIPTION
Node 14 and 16 are EOL now so we can remove them from our CI and adopt the new LTS node.js v20.