### PR TITLE
Add highlight metadata to autocomplete client

### DIFF
--- a/.changeset/silly-badgers-hug.md
+++ b/.changeset/silly-badgers-hug.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/autocomplete-client": minor
+---
+
+Add highlight metadata

--- a/packages/autocomplete-client/__tests__/test.utils.ts
+++ b/packages/autocomplete-client/__tests__/test.utils.ts
@@ -17,4 +17,59 @@ const meilisearchClient = new MeiliSearch({
   apiKey: 'masterKey',
 })
 
+export const MOVIES = [
+  {
+    id: 2,
+    title: 'Ariel',
+    overview:
+      "Taisto Kasurinen is a Finnish coal miner whose father has just committed suicide and who is framed for a crime he did not commit. In jail, he starts to dream about leaving the country and starting a new life. He escapes from prison but things don't go as planned...",
+    genres: ['Drama', 'Crime', 'Comedy'],
+    poster: 'https://image.tmdb.org/t/p/w500/ojDg0PGvs6R9xYFodRct2kdI6wC.jpg',
+    release_date: 593395200,
+  },
+  {
+    id: 5,
+    title: 'Four Rooms',
+    overview:
+      "It's Ted the Bellhop's first night on the job...and the hotel's very unusual guests are about to place him in some outrageous predicaments. It seems that this evening's room service is serving up one unbelievable happening after another.",
+    genres: ['Crime', 'Comedy'],
+    poster: 'https://image.tmdb.org/t/p/w500/75aHn1NOYXh4M7L5shoeQ6NGykP.jpg',
+    release_date: 818467200,
+  },
+  {
+    id: 6,
+    title: 'Judgment Night',
+    overview:
+      'While racing to a boxing match, Frank, Mike, John and Rey get more than they bargained for. A wrong turn lands them directly in the path of Fallon, a vicious, wise-cracking drug lord. After accidentally witnessing Fallon murder a disloyal henchman, the four become his unwilling prey in a savage game of cat & mouse as they are mercilessly stalked through the urban jungle in this taut suspense drama',
+    genres: ['Action', 'Thriller', 'Crime'],
+    poster: 'https://image.tmdb.org/t/p/w500/rYFAvSPlQUCebayLcxyK79yvtvV.jpg',
+    release_date: 750643200,
+  },
+  {
+    id: 11,
+    title: 'Star Wars',
+    overview:
+      'Princess Leia is captured and held hostage by the evil Imperial forces in their effort to take over the galactic Empire. Venturesome Luke Skywalker and dashing captain Han Solo team together with the loveable robot duo R2-D2 and C-3PO to rescue the beautiful princess and restore peace and justice in the Empire.',
+    genres: ['Adventure', 'Action', 'Science Fiction'],
+    poster: 'https://image.tmdb.org/t/p/w500/6FfCtAuVAW8XJjZ7eWeLibRLWTw.jpg',
+    release_date: 233366400,
+  },
+  {
+    id: 30,
+    title: 'Magnetic Rose',
+    overview: '',
+    genres: ['Animation', 'Science Fiction'],
+    poster: 'https://image.tmdb.org/t/p/w500/gSuHDeWemA1menrwfMRChnSmMVN.jpg',
+    release_date: 819676800,
+  },
+  {
+    id: 24,
+    title: 'Kill Bill: Vol. 1',
+    overview: null,
+    genres: ['Action', 'Crime'],
+    poster: 'https://image.tmdb.org/t/p/w500/v7TaX8kXMXs5yFFGR41guUDNcnB.jpg',
+    release_date: 1065744000,
+  },
+]
+
 export { HOST, API_KEY, searchClient, dataset, meilisearchClient }

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -1,28 +1,31 @@
 import { fetchMeilisearchResults } from '../fetchMeilisearchResults'
 import {
   searchClient,
-  dataset,
+  MOVIES,
   meilisearchClient,
 } from '../../../__tests__/test.utils'
 import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../../constants'
 
+type Movie = (typeof MOVIES)[number]
+const INDEX_NAME = 'movies'
+
 beforeAll(async () => {
-  await meilisearchClient.deleteIndex('testUid')
-  const task = await meilisearchClient.index('testUid').addDocuments(dataset)
+  await meilisearchClient.deleteIndex(INDEX_NAME)
+  const task = await meilisearchClient.index(INDEX_NAME).addDocuments(MOVIES)
   await meilisearchClient.waitForTask(task.taskUid)
 })
 
 afterAll(async () => {
-  await meilisearchClient.deleteIndex('testUid')
+  await meilisearchClient.deleteIndex(INDEX_NAME)
 })
 
 describe('fetchMeilisearchResults', () => {
   test('with default options', async () => {
-    const results = await fetchMeilisearchResults<(typeof dataset)[0]>({
+    const results = await fetchMeilisearchResults<Movie>({
       searchClient,
       queries: [
         {
-          indexName: 'testUid',
+          indexName: INDEX_NAME,
           query: '',
         },
       ],
@@ -32,87 +35,93 @@ describe('fetchMeilisearchResults', () => {
     expect(results[0].hits[1].id).toEqual(2)
   })
 
-  test('with custom pagination', async () => {
-    const results = await fetchMeilisearchResults({
-      searchClient,
-      queries: [
-        {
-          indexName: 'testUid',
-          query: 'Hit',
-          params: {
-            hitsPerPage: 1,
-            page: 1,
-          },
-        },
-      ],
-    })
+  // test('with custom pagination', async () => {
+  //   const results = await fetchMeilisearchResults({
+  //     searchClient,
+  //     queries: [
+  //       {
+  //         indexName: INDEX_NAME,
+  //         query: 'Hit',
+  //         params: {
+  //           hitsPerPage: 1,
+  //           page: 1,
+  //         },
+  //       },
+  //     ],
+  //   })
 
-    expect(results[0].hits[0].id).toEqual(2)
-  })
+  //   expect(results[0].hits[0].id).toEqual(2)
+  // })
 
-  test('with custom highlight tags', async () => {
-    const results = await fetchMeilisearchResults({
-      searchClient,
-      queries: [
-        {
-          indexName: 'testUid',
-          query: 'Hit',
-          params: {
-            highlightPreTag: '<b>',
-            highlightPostTag: '</b>',
-          },
-        },
-      ],
-    })
+  // test('with custom highlight tags', async () => {
+  //   const results = await fetchMeilisearchResults({
+  //     searchClient,
+  //     queries: [
+  //       {
+  //         indexName: INDEX_NAME,
+  //         query: 'Hit',
+  //         params: {
+  //           highlightPreTag: '<b>',
+  //           highlightPostTag: '</b>',
+  //         },
+  //       },
+  //     ],
+  //   })
 
-    expect(results[0].hits[0]._highlightResult?.label?.value).toEqual(
-      '<b>Hit</b> 1'
-    )
-  })
+  //   expect(results[0].hits[0]._highlightResult?.label?.value).toEqual(
+  //     '<b>Hit</b> 1'
+  //   )
+  // })
 
-  test('with highlighting metadata', async () => {
-    const results = await fetchMeilisearchResults({
-      searchClient,
-      queries: [
-        {
-          indexName: 'testUid',
-          query: 'Hit',
-        },
-      ],
-    })
+  // test('with highlighting metadata', async () => {
+  //   const results = await fetchMeilisearchResults({
+  //     searchClient,
+  //     queries: [
+  //       {
+  //         indexName: INDEX_NAME,
+  //         query: 'Hit',
+  //       },
+  //     ],
+  //   })
 
-    expect(results[0].hits[0]._highlightResult).toEqual({
-      id: {
-        value: '1',
-        fullyHighlighted: false,
-        matchLevel: 'none',
-        matchedWords: [],
-      },
-      label: {
-        value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} 1`,
-        fullyHighlighted: false,
-        matchLevel: 'partial',
-        matchedWords: ['Hit'],
-      },
-    })
-  })
+  //   expect(results[0].hits[0]._highlightResult).toEqual({
+  //     id: {
+  //       value: '1',
+  //       fullyHighlighted: false,
+  //       matchLevel: 'none',
+  //       matchedWords: [],
+  //     },
+  //     label: {
+  //       value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} 1`,
+  //       fullyHighlighted: false,
+  //       matchLevel: 'partial',
+  //       matchedWords: ['Hit'],
+  //     },
+  //   })
+  // })
 
-  test('with fully highlighted match', async () => {
-    const results = await fetchMeilisearchResults({
-      searchClient,
-      queries: [
-        {
-          indexName: 'testUid',
-          query: 'Hit',
-        },
-      ],
-    })
+  // test('with fully highlighted match', async () => {
+  //   const pre = '<em>'
+  //   const post = '</em>'
+  //   const results = await fetchMeilisearchResults({
+  //     searchClient,
+  //     queries: [
+  //       {
+  //         indexName: INDEX_NAME,
+  //         query: 'Hit 1',
+  //         params: {
+  //           highlightPreTag: pre,
+  //           highlightPostTag: post,
+  //         },
+  //       },
+  //     ],
+  //   })
 
-    expect(results[0].hits[0]._highlightResult?.label).toEqual({
-      value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} ${HIGHLIGHT_PRE_TAG}2${HIGHLIGHT_POST_TAG}`,
-      fullyHighlighted: true,
-      matchLevel: 'partial',
-      matchedWords: ['Hit'],
-    })
-  })
+  //   expect(results[0].hits[0]._highlightResult?.label).toEqual({
+  //     value: `${pre}Hit${post} ${pre}1${post}`,
+  //     fullyHighlighted: true,
+  //     matchLevel: 'full',
+  //     matchedWords: ['Hit'],
+  //   })
+  // })
 })

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -4,11 +4,10 @@ import {
   MOVIES,
   meilisearchClient,
 } from '../../../__tests__/test.utils'
-import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../../constants'
 
 type Movie = (typeof MOVIES)[number]
 
-const INDEX_NAME = 'movies'
+const INDEX_NAME = 'movies_fetch-meilisearch-results-test'
 const FIRST_ITEM_ID = MOVIES[0].id
 const SECOND_ITEM_ID = MOVIES[1].id
 

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -79,26 +79,22 @@ describe('fetchMeilisearchResults', () => {
     })
   })
 
-  // test('with fully highlighted match', async () => {
-  //   const results = await fetchMeilisearchResults({
-  //     searchClient,
-  //     queries: [
-  //       {
-  //         indexName: 'testUid',
-  //         query: 'Hit 2',
-  //         params: {
-  //           highlightPreTag: '<test>',
-  //           highlightPostTag: '</test>',
-  //         },
-  //       },
-  //     ],
-  //   })
+  test('with fully highlighted match', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: 'testUid',
+          query: 'Hit',
+        },
+      ],
+    })
 
-  //   expect(results[0].hits[0]._highlightResult?.label).toEqual({
-  //     value: '<test>Hit</test> <test>2</test>',
-  //     fullyHighlighted: true,
-  //     matchLevel: 'full',
-  //     matchedWords: ['Hit', '2'],
-  //   })
-  // })
+    expect(results[0].hits[0]._highlightResult?.label).toEqual({
+      value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} ${HIGHLIGHT_PRE_TAG}2${HIGHLIGHT_POST_TAG}`,
+      fullyHighlighted: true,
+      matchLevel: 'partial',
+      matchedWords: ['Hit'],
+    })
+  })
 })

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -76,55 +76,47 @@ describe('fetchMeilisearchResults', () => {
     )
   })
 
-  // test('with highlighting metadata', async () => {
-  //   const results = await fetchMeilisearchResults({
-  //     searchClient,
-  //     queries: [
-  //       {
-  //         indexName: INDEX_NAME,
-  //         query: 'Hit',
-  //       },
-  //     ],
-  //   })
+  test('highlight results contain highlighting metadata', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: INDEX_NAME,
+          query: 'Ariel',
+        },
+      ],
+    })
 
-  //   expect(results[0].hits[0]._highlightResult).toEqual({
-  //     id: {
-  //       value: '1',
-  //       fullyHighlighted: false,
-  //       matchLevel: 'none',
-  //       matchedWords: [],
-  //     },
-  //     label: {
-  //       value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} 1`,
-  //       fullyHighlighted: false,
-  //       matchLevel: 'partial',
-  //       matchedWords: ['Hit'],
-  //     },
-  //   })
-  // })
+    expect(results[0].hits[0]._highlightResult?.id?.fullyHighlighted).toEqual(
+      false
+    )
+    expect(results[0].hits[0]._highlightResult?.id?.matchLevel).toEqual('none')
+    expect(results[0].hits[0]._highlightResult?.id?.matchedWords).toEqual([])
+    expect(results[0].hits[0]._highlightResult?.id?.value).toEqual(String(2))
+  })
 
-  // test('with fully highlighted match', async () => {
-  //   const pre = '<em>'
-  //   const post = '</em>'
-  //   const results = await fetchMeilisearchResults({
-  //     searchClient,
-  //     queries: [
-  //       {
-  //         indexName: INDEX_NAME,
-  //         query: 'Hit 1',
-  //         params: {
-  //           highlightPreTag: pre,
-  //           highlightPostTag: post,
-  //         },
-  //       },
-  //     ],
-  //   })
+  test('with fully highlighted match', async () => {
+    const pre = '<em>'
+    const post = '</em>'
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: INDEX_NAME,
+          query: 'Ariel',
+          params: {
+            highlightPreTag: pre,
+            highlightPostTag: post,
+          },
+        },
+      ],
+    })
 
-  //   expect(results[0].hits[0]._highlightResult?.label).toEqual({
-  //     value: `${pre}Hit${post} ${pre}1${post}`,
-  //     fullyHighlighted: true,
-  //     matchLevel: 'full',
-  //     matchedWords: ['Hit'],
-  //   })
-  // })
+    expect(results[0].hits[0]._highlightResult?.title).toEqual({
+      value: `${pre}Ariel${post}`,
+      fullyHighlighted: true,
+      matchLevel: 'full',
+      matchedWords: ['Ariel'],
+    })
+  })
 })

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -41,6 +41,7 @@ describe('fetchMeilisearchResults', () => {
           query: 'Hit',
           params: {
             hitsPerPage: 1,
+            // TODO: this is not tested for
             highlightPreTag: '<test>',
             highlightPostTag: '</test>',
             page: 1,

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -7,7 +7,10 @@ import {
 import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../../constants'
 
 type Movie = (typeof MOVIES)[number]
+
 const INDEX_NAME = 'movies'
+const FIRST_ITEM_ID = MOVIES[0].id
+const SECOND_ITEM_ID = MOVIES[1].id
 
 beforeAll(async () => {
   await meilisearchClient.deleteIndex(INDEX_NAME)
@@ -31,27 +34,27 @@ describe('fetchMeilisearchResults', () => {
       ],
     })
 
-    expect(results[0].hits[0].id).toEqual(2)
-    expect(results[0].hits[1].id).toEqual(5)
+    expect(results[0].hits[0].id).toEqual(FIRST_ITEM_ID)
+    expect(results[0].hits[1].id).toEqual(SECOND_ITEM_ID)
   })
 
-  // test('with custom pagination', async () => {
-  //   const results = await fetchMeilisearchResults({
-  //     searchClient,
-  //     queries: [
-  //       {
-  //         indexName: INDEX_NAME,
-  //         query: 'Hit',
-  //         params: {
-  //           hitsPerPage: 1,
-  //           page: 1,
-  //         },
-  //       },
-  //     ],
-  //   })
+  test('with custom pagination', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: INDEX_NAME,
+          query: '',
+          params: {
+            hitsPerPage: 1,
+            page: 1, // pages start at 0
+          },
+        },
+      ],
+    })
 
-  //   expect(results[0].hits[0].id).toEqual(2)
-  // })
+    expect(results[0].hits[0].id).toEqual(SECOND_ITEM_ID)
+  })
 
   // test('with custom highlight tags', async () => {
   //   const results = await fetchMeilisearchResults({

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -31,8 +31,8 @@ describe('fetchMeilisearchResults', () => {
       ],
     })
 
-    expect(results[0].hits[0].id).toEqual(1)
-    expect(results[0].hits[1].id).toEqual(2)
+    expect(results[0].hits[0].id).toEqual(2)
+    expect(results[0].hits[1].id).toEqual(5)
   })
 
   // test('with custom pagination', async () => {

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -56,25 +56,25 @@ describe('fetchMeilisearchResults', () => {
     expect(results[0].hits[0].id).toEqual(SECOND_ITEM_ID)
   })
 
-  // test('with custom highlight tags', async () => {
-  //   const results = await fetchMeilisearchResults({
-  //     searchClient,
-  //     queries: [
-  //       {
-  //         indexName: INDEX_NAME,
-  //         query: 'Hit',
-  //         params: {
-  //           highlightPreTag: '<b>',
-  //           highlightPostTag: '</b>',
-  //         },
-  //       },
-  //     ],
-  //   })
+  test('with custom highlight tags', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: INDEX_NAME,
+          query: 'Ariel',
+          params: {
+            highlightPreTag: '<b>',
+            highlightPostTag: '</b>',
+          },
+        },
+      ],
+    })
 
-  //   expect(results[0].hits[0]._highlightResult?.label?.value).toEqual(
-  //     '<b>Hit</b> 1'
-  //   )
-  // })
+    expect(results[0].hits[0]._highlightResult?.title?.value).toEqual(
+      '<b>Ariel</b>'
+    )
+  })
 
   // test('with highlighting metadata', async () => {
   //   const results = await fetchMeilisearchResults({

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -4,6 +4,7 @@ import {
   dataset,
   meilisearchClient,
 } from '../../../__tests__/test.utils'
+import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../../constants'
 
 beforeAll(async () => {
   await meilisearchClient.deleteIndex('testUid')
@@ -49,9 +50,55 @@ describe('fetchMeilisearchResults', () => {
     })
 
     expect(results[0].hits[0].id).toEqual(2)
+  })
+
+  test('with highlighting metadata', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: 'testUid',
+          query: 'Hit',
+        },
+      ],
+    })
+
     expect(results[0].hits[0]._highlightResult).toEqual({
-      id: { value: '2' },
-      label: { value: '<test>Hit</test> 2' },
+      id: {
+        value: '1',
+        fullyHighlighted: false,
+        matchLevel: 'none',
+        matchedWords: [],
+      },
+      label: {
+        value: `${HIGHLIGHT_PRE_TAG}Hit${HIGHLIGHT_POST_TAG} 1`,
+        fullyHighlighted: false,
+        matchLevel: 'partial',
+        matchedWords: ['Hit'],
+      },
     })
   })
+
+  // test('with fully highlighted match', async () => {
+  //   const results = await fetchMeilisearchResults({
+  //     searchClient,
+  //     queries: [
+  //       {
+  //         indexName: 'testUid',
+  //         query: 'Hit 2',
+  //         params: {
+  //           highlightPreTag: '<test>',
+  //           highlightPostTag: '</test>',
+  //         },
+  //       },
+  //     ],
+  //   })
+
+  //   expect(results[0].hits[0]._highlightResult?.label).toEqual({
+  //     value: '<test>Hit</test> <test>2</test>',
+  //     fullyHighlighted: true,
+  //     matchLevel: 'full',
+  //     matchedWords: ['Hit', '2'],
+  //   })
+  // })
 })

--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -32,7 +32,7 @@ describe('fetchMeilisearchResults', () => {
     expect(results[0].hits[1].id).toEqual(2)
   })
 
-  test('with custom search parameters', async () => {
+  test('with custom pagination', async () => {
     const results = await fetchMeilisearchResults({
       searchClient,
       queries: [
@@ -41,9 +41,6 @@ describe('fetchMeilisearchResults', () => {
           query: 'Hit',
           params: {
             hitsPerPage: 1,
-            // TODO: this is not tested for
-            highlightPreTag: '<test>',
-            highlightPostTag: '</test>',
             page: 1,
           },
         },
@@ -51,6 +48,26 @@ describe('fetchMeilisearchResults', () => {
     })
 
     expect(results[0].hits[0].id).toEqual(2)
+  })
+
+  test('with custom highlight tags', async () => {
+    const results = await fetchMeilisearchResults({
+      searchClient,
+      queries: [
+        {
+          indexName: 'testUid',
+          query: 'Hit',
+          params: {
+            highlightPreTag: '<b>',
+            highlightPostTag: '</b>',
+          },
+        },
+      ],
+    })
+
+    expect(results[0].hits[0]._highlightResult?.label?.value).toEqual(
+      '<b>Hit</b> 1'
+    )
   })
 
   test('with highlighting metadata', async () => {

--- a/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
+++ b/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
@@ -72,27 +72,16 @@ export function fetchMeilisearchResults<TRecord = Record<string, any>>({
                     | [keyof TRecord, Array<{ value: string }>] // if the field is an array
                   >
                 ).reduce((acc, [field, highlightResult]) => {
-                  // if the field is an array, highlightResult is an array of objects
-                  if (Array.isArray(highlightResult)) {
-                    return {
-                      ...acc,
-                      [field]: highlightResult.map((highlight) =>
-                        calculateHighlightMetadata(
-                          query.query || '',
-                          query.params?.highlightPreTag || HIGHLIGHT_PRE_TAG,
-                          query.params?.highlightPostTag || HIGHLIGHT_POST_TAG,
-                          highlight.value
-                        )
-                      ),
-                    }
-                  }
                   return {
                     ...acc,
-                    [field]: calculateHighlightMetadata(
-                      query.query || '',
-                      query.params?.highlightPreTag || HIGHLIGHT_PRE_TAG,
-                      query.params?.highlightPostTag || HIGHLIGHT_POST_TAG,
-                      highlightResult.value
+                    // if the field is an array, highlightResult is an array of objects
+                    [field]: mapOneOrMany(highlightResult, (highlightResult) =>
+                      calculateHighlightMetadata(
+                        query.query || '',
+                        query.params?.highlightPreTag || HIGHLIGHT_PRE_TAG,
+                        query.params?.highlightPostTag || HIGHLIGHT_POST_TAG,
+                        highlightResult.value
+                      )
                     ),
                   }
                 }, {} as HighlightResult<TRecord>),
@@ -152,4 +141,9 @@ function calculateHighlightMetadata(
     matchLevel,
     matchedWords: matches,
   }
+}
+
+// Helper to apply a function to a single value or an array of values
+function mapOneOrMany<T, U>(value: T | T[], mapFn: (value: T) => U): U | U[] {
+  return Array.isArray(value) ? value.map(mapFn) : mapFn(value)
 }

--- a/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
+++ b/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
@@ -20,6 +20,13 @@ interface SearchParams {
   queries: AlgoliaMultipleQueriesQuery[]
 }
 
+interface HighlightMetadata {
+  value: string
+  fullyHighlighted: boolean
+  matchLevel: 'none' | 'partial' | 'full'
+  matchedWords: string[]
+}
+
 export function fetchMeilisearchResults<TRecord = Record<string, any>>({
   searchClient,
   queries,
@@ -42,7 +49,60 @@ export function fetchMeilisearchResults<TRecord = Record<string, any>>({
     )
     .then(
       (response: Awaited<ReturnType<typeof searchClient.search<TRecord>>>) => {
-        return response.results
+        return response.results.map(
+          (result: AlgoliaSearchResponse<TRecord>) => ({
+            ...result,
+            hits: result.hits.map(
+              (hit: AlgoliaSearchResponse<TRecord>['hits'][number]) => ({
+                ...hit,
+                _highlightResult: hit._highlightResult
+                  ? Object.entries(hit._highlightResult).reduce(
+                      (acc, [key, value]) => ({
+                        ...acc,
+                        [key]: calculateHighlightMetadata(value.value),
+                      }),
+                      {}
+                    )
+                  : {},
+              })
+            ),
+          })
+        )
       }
     )
+}
+
+function calculateHighlightMetadata(
+  value: string,
+  preTag: string = HIGHLIGHT_PRE_TAG,
+  postTag: string = HIGHLIGHT_POST_TAG
+): HighlightMetadata {
+  // Find all highlighted words
+  const highlightRegex = new RegExp(`${preTag}(.*?)${postTag}`, 'g')
+  const matches: string[] = []
+  let match
+  while ((match = highlightRegex.exec(value)) !== null) {
+    matches.push(match[1])
+  }
+  const matchedWords = matches
+
+  // Remove highlight tags for comparison
+  const cleanValue = value.replace(new RegExp(`${preTag}|${postTag}`, 'g'), '')
+
+  // Calculate if fully highlighted
+  const highlightedText = matches.join('')
+  const fullyHighlighted = cleanValue === highlightedText
+
+  // Determine match level
+  let matchLevel: 'none' | 'partial' | 'full' = 'none'
+  if (matches.length > 0) {
+    matchLevel = fullyHighlighted ? 'full' : 'partial'
+  }
+
+  return {
+    value,
+    fullyHighlighted,
+    matchLevel,
+    matchedWords,
+  }
 }

--- a/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
+++ b/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
@@ -140,7 +140,7 @@ function calculateHighlightMetadata(
   // Determine match level:
   // - 'none' if no matches
   // - 'partial' if some matches but not fully highlighted
-  // - 'full' if all text is fully highlighted
+  // - 'full' if the highlighted text is the entire field value content
   let matchLevel: 'none' | 'partial' | 'full' = 'none'
   if (matches.length > 0) {
     matchLevel = cleanValue.includes(query) ? 'full' : 'partial'

--- a/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
+++ b/packages/autocomplete-client/src/search/fetchMeilisearchResults.ts
@@ -78,23 +78,26 @@ function calculateHighlightMetadata(
   preTag: string = HIGHLIGHT_PRE_TAG,
   postTag: string = HIGHLIGHT_POST_TAG
 ): HighlightMetadata {
-  // Find all highlighted words
+  // Extract all highlighted segments
   const highlightRegex = new RegExp(`${preTag}(.*?)${postTag}`, 'g')
   const matches: string[] = []
   let match
   while ((match = highlightRegex.exec(value)) !== null) {
     matches.push(match[1])
   }
-  const matchedWords = matches
 
-  // Remove highlight tags for comparison
+  // Remove highlight tags to get the original, unhighlighted text
   const cleanValue = value.replace(new RegExp(`${preTag}|${postTag}`, 'g'), '')
 
-  // Calculate if fully highlighted
+  // Determine if the entire attribute is highlighted
+  // fullyHighlighted = true if cleanValue and the concatenation of all matched segments are identical
   const highlightedText = matches.join('')
   const fullyHighlighted = cleanValue === highlightedText
 
-  // Determine match level
+  // Determine match level:
+  // - 'none' if no matches
+  // - 'partial' if some matches but not fully highlighted
+  // - 'full' if all text is fully highlighted
   let matchLevel: 'none' | 'partial' | 'full' = 'none'
   if (matches.length > 0) {
     matchLevel = fullyHighlighted ? 'full' : 'partial'
@@ -104,6 +107,6 @@ function calculateHighlightMetadata(
     value,
     fullyHighlighted,
     matchLevel,
-    matchedWords,
+    matchedWords: matches,
   }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1337

## What does this PR do?

This PR enriches the `_highlightResult` object with metadata:
- `fullyHighlighted`:  whether the highlighted text covers the entire field
- `matchLevel`: degree of the match (none, partial, or full)
- `matchedWords`: array of words matched

While adding the necessary tests, I also improved the existing tests for `fetchMeilisearchResults.ts`.
