### PR TITLE
Add vector search param

### DIFF
--- a/.changeset/strong-dodos-carry.md
+++ b/.changeset/strong-dodos-carry.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": minor
+---
+
+Adds vector search param to support vector search with user-provided embedding

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/__tests__/search-params.test.ts
@@ -95,6 +95,19 @@ describe('Parameters adapter', () => {
     expect(searchParams.hybrid).toBe(hybridSearchConfig)
   })
 
+  test('vector can be set via search parameters', () => {
+    const vector = [0, 1, 2]
+
+    const searchParams = adaptSearchParams({
+      ...DEFAULT_CONTEXT,
+      meiliSearchParams: {
+        vector: vector,
+      },
+    })
+
+    expect(searchParams.vector).toBe(vector)
+  }) 
+
   test('ranking score threshold can be set via search parameters', () => {
     const rankingScoreThreshold = 0.974
 

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -67,7 +67,6 @@ function setFinitePagination(
 export function MeiliParamsCreator(searchContext: SearchContext) {
   const {
     query,
-    vector,
     indexUid,
     facets,
     attributesToSnippet,

--- a/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
+++ b/packages/instant-meilisearch/src/adapter/search-request-adapter/search-params-adapter.ts
@@ -67,6 +67,7 @@ function setFinitePagination(
 export function MeiliParamsCreator(searchContext: SearchContext) {
   const {
     query,
+    vector,
     indexUid,
     facets,
     attributesToSnippet,
@@ -238,6 +239,12 @@ export function MeiliParamsCreator(searchContext: SearchContext) {
         meiliSearchParams.hybrid = value
       }
     },
+    addVector() {
+      const value = overrideParams?.vector
+      if (value !== undefined) {
+        meiliSearchParams.vector = value
+      }      
+    },
     addDistinct() {
       const value = overrideParams?.distinct
       if (value !== undefined) {
@@ -282,6 +289,7 @@ export function adaptSearchParams(
   meilisearchParams.addShowRankingScore()
   meilisearchParams.addAttributesToSearchOn()
   meilisearchParams.addHybridSearch()
+  meilisearchParams.addVector()
   meilisearchParams.addDistinct()
   meilisearchParams.addRankingScoreThreshold()
 

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -115,6 +115,7 @@ export type SearchContext = InstantMeiliSearchOptions &
     pagination: PaginationState
     indexUid: string
     sort?: string | string[]
+    vector?: number[]
   }
 
 export type InstantSearchGeoParams = {

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -115,7 +115,6 @@ export type SearchContext = InstantMeiliSearchOptions &
     pagination: PaginationState
     indexUid: string
     sort?: string | string[]
-    vector?: number[]
   }
 
 export type InstantSearchGeoParams = {

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -53,6 +53,7 @@ export type OverridableMeiliSearchSearchParameters = Pick<
   | 'highlightPreTag'
   | 'highlightPostTag'
   | 'hybrid'
+  | 'vector'
   | 'matchingStrategy'
   | 'rankingScoreThreshold'
   | 'showMatchesPosition'


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1351

## What does this PR do?
- Adds vector search param to support [vector search with user-provided embedding](https://www.meilisearch.com/docs/learn/ai_powered_search/search_with_user_provided_embeddings#vector-search-with-user-provided-embeddings)


