### PR TITLE
Bump meilisearch-js to v0.50

### DIFF
--- a/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
+++ b/packages/autocomplete-client/src/search/__tests__/fetchMeilisearchResults.test.ts
@@ -14,8 +14,7 @@ const SECOND_ITEM_ID = MOVIES[1].id
 
 beforeAll(async () => {
   await meilisearchClient.deleteIndex(INDEX_NAME)
-  const task = await meilisearchClient.index(INDEX_NAME).addDocuments(MOVIES)
-  await meilisearchClient.waitForTask(task.taskUid)
+  await meilisearchClient.index(INDEX_NAME).addDocuments(MOVIES).waitTask()
 })
 
 afterAll(async () => {

--- a/packages/instant-meilisearch/__tests__/configure.attributes-to-retrieve.test.ts
+++ b/packages/instant-meilisearch/__tests__/configure.attributes-to-retrieve.test.ts
@@ -8,13 +8,12 @@ import {
 
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
 
-    const documentsTask = await meilisearchClient
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('attributesToRetrieve on no attributes', async () => {

--- a/packages/instant-meilisearch/__tests__/configure.attributes-to-retrieve.test.ts
+++ b/packages/instant-meilisearch/__tests__/configure.attributes-to-retrieve.test.ts
@@ -10,10 +10,7 @@ describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
 
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('attributesToRetrieve on no attributes', async () => {

--- a/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
+++ b/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
@@ -6,17 +6,16 @@ describe('Custom HTTP client tests', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
 
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('a custom HTTP client', async () => {
-    const httpClient = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      const result = await fetch(url, init)
-      return await result.json()
-    })
+    const httpClient = vi.fn(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        const result = await fetch(url, init)
+        return await result.json()
+      }
+    )
 
     const { searchClient } = instantMeiliSearch(
       'http://localhost:7700',

--- a/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
+++ b/packages/instant-meilisearch/__tests__/custom-http-client.test.ts
@@ -4,17 +4,16 @@ import { meilisearchClient, dataset } from './assets/utils.js'
 
 describe('Custom HTTP client tests', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
 
-    const documentsTask = await meilisearchClient
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('a custom HTTP client', async () => {
-    const httpClient = vi.fn(async (url: string, init?: RequestInit) => {
+    const httpClient = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
       const result = await fetch(url, init)
       return await result.json()
     })

--- a/packages/instant-meilisearch/__tests__/disjunctive-facet-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/disjunctive-facet-search.test.ts
@@ -22,9 +22,7 @@ describe('Keep zero facets tests', () => {
     })
 
     await moviesIndex.addDocuments(movies)
-    const response = await gamesIndex.addDocuments(games)
-
-    await meilisearchClient.waitForTask(response.taskUid)
+    await gamesIndex.addDocuments(games).waitTask()
   })
 
   test('searching on one index with facet filtering', async () => {

--- a/packages/instant-meilisearch/__tests__/facet-stats.test.ts
+++ b/packages/instant-meilisearch/__tests__/facet-stats.test.ts
@@ -8,10 +8,7 @@ describe('Facet stats tests', () => {
       .index('movies')
       .updateFilterableAttributes(['genres', 'release_date', 'id'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('Facet stats on an empty facets array', async () => {

--- a/packages/instant-meilisearch/__tests__/facet-stats.test.ts
+++ b/packages/instant-meilisearch/__tests__/facet-stats.test.ts
@@ -3,15 +3,15 @@ import { searchClient, dataset, meilisearchClient } from './assets/utils.js'
 
 describe('Facet stats tests', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres', 'release_date', 'id'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('Facet stats on an empty facets array', async () => {

--- a/packages/instant-meilisearch/__tests__/facets-distribution.test.ts
+++ b/packages/instant-meilisearch/__tests__/facets-distribution.test.ts
@@ -3,15 +3,15 @@ import { searchClient, dataset, meilisearchClient } from './assets/utils.js'
 
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('empty array on facetDistribution', async () => {

--- a/packages/instant-meilisearch/__tests__/facets-distribution.test.ts
+++ b/packages/instant-meilisearch/__tests__/facets-distribution.test.ts
@@ -8,10 +8,7 @@ describe('Instant Meilisearch Browser test', () => {
       .index('movies')
       .updateFilterableAttributes(['genres'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('empty array on facetDistribution', async () => {

--- a/packages/instant-meilisearch/__tests__/filter.test.ts
+++ b/packages/instant-meilisearch/__tests__/filter.test.ts
@@ -8,8 +8,7 @@ import {
 
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes([
@@ -18,10 +17,11 @@ describe('Instant Meilisearch Browser test', () => {
         'numberField',
         'crazy_\\_"field"',
       ])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('one string facet on filter without a query', async () => {

--- a/packages/instant-meilisearch/__tests__/filter.test.ts
+++ b/packages/instant-meilisearch/__tests__/filter.test.ts
@@ -18,10 +18,7 @@ describe('Instant Meilisearch Browser test', () => {
         'crazy_\\_"field"',
       ])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('one string facet on filter without a query', async () => {

--- a/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
+++ b/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
@@ -5,14 +5,14 @@ import { instantMeiliSearch } from '../src/index.js'
 describe('Default facet distribution', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
-    await meilisearchClient.index('movies').updateSettings({
-      filterableAttributes: ['genres', 'release_date'],
-      sortableAttributes: ['release_date'],
-    }).waitTask()
     await meilisearchClient
       .index('movies')
-      .addDocuments(dataset)
+      .updateSettings({
+        filterableAttributes: ['genres', 'release_date'],
+        sortableAttributes: ['release_date'],
+      })
       .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   // Without facets

--- a/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
+++ b/packages/instant-meilisearch/__tests__/first-facets-distribution.test.ts
@@ -4,16 +4,15 @@ import { instantMeiliSearch } from '../src/index.js'
 
 describe('Default facet distribution', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient.index('movies').updateSettings({
       filterableAttributes: ['genres', 'release_date'],
       sortableAttributes: ['release_date'],
-    })
-    const documentsTask = await meilisearchClient
+    }).waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   // Without facets

--- a/packages/instant-meilisearch/__tests__/geosearch.test.ts
+++ b/packages/instant-meilisearch/__tests__/geosearch.test.ts
@@ -8,16 +8,16 @@ import {
 
 describe('Instant Meilisearch Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('geotest')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('geotest').waitTask()
     await meilisearchClient
       .index('geotest')
       .updateFilterableAttributes(['_geo'])
-    await meilisearchClient.index('geotest').updateSortableAttributes(['_geo'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient.index('geotest').updateSortableAttributes(['_geo']).waitTask()
+    await meilisearchClient
       .index('geotest')
       .addDocuments(geoDataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('aroundRadius and aroundLatLng in geo search', async () => {

--- a/packages/instant-meilisearch/__tests__/geosearch.test.ts
+++ b/packages/instant-meilisearch/__tests__/geosearch.test.ts
@@ -13,11 +13,11 @@ describe('Instant Meilisearch Browser test', () => {
       .index('geotest')
       .updateFilterableAttributes(['_geo'])
       .waitTask()
-    await meilisearchClient.index('geotest').updateSortableAttributes(['_geo']).waitTask()
     await meilisearchClient
       .index('geotest')
-      .addDocuments(geoDataset)
+      .updateSortableAttributes(['_geo'])
       .waitTask()
+    await meilisearchClient.index('geotest').addDocuments(geoDataset).waitTask()
   })
 
   test('aroundRadius and aroundLatLng in geo search', async () => {

--- a/packages/instant-meilisearch/__tests__/highlight.test.ts
+++ b/packages/instant-meilisearch/__tests__/highlight.test.ts
@@ -13,10 +13,7 @@ describe('Highlight Browser test', () => {
       .index('movies')
       .updateFilterableAttributes(['genres'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('one attributesToHighlight on wrong attribute placeholder', async () => {

--- a/packages/instant-meilisearch/__tests__/highlight.test.ts
+++ b/packages/instant-meilisearch/__tests__/highlight.test.ts
@@ -8,15 +8,15 @@ import {
 
 describe('Highlight Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('one attributesToHighlight on wrong attribute placeholder', async () => {

--- a/packages/instant-meilisearch/__tests__/instantiation.test.ts
+++ b/packages/instant-meilisearch/__tests__/instantiation.test.ts
@@ -44,7 +44,7 @@ describe('InstantMeiliSearch instantiation', () => {
 
   test('instantiation with custom request config with correct type', () => {
     const searchClient = instantMeiliSearch('http://localhost:7700', '', {
-      requestConfig: {},
+      requestInit: {},
     })
 
     expect(searchClient).toBeTruthy()
@@ -52,7 +52,7 @@ describe('InstantMeiliSearch instantiation', () => {
 
   test('instantiation with custom request config set to undefined', () => {
     const searchClient = instantMeiliSearch('http://localhost:7700', '', {
-      requestConfig: undefined,
+      requestInit: undefined,
     })
 
     expect(searchClient).toBeTruthy()
@@ -62,9 +62,9 @@ describe('InstantMeiliSearch instantiation', () => {
     expect(() => {
       instantMeiliSearch('http://localhost:7700', '', {
         // @ts-expect-error
-        requestConfig: '',
+        requestInit: '',
       })
-    }).toThrow('Provided requestConfig should be an object')
+    }).toThrow('Provided requestInit should be an object')
   })
 
   test('instantiation with custom HTTP client with correct type', () => {

--- a/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
@@ -12,12 +12,16 @@ describe('Multi-index search test', () => {
     await moviesIndex.delete()
     await gamesIndex.delete()
 
-    await moviesIndex.updateSettings({
-      filterableAttributes: ['genres', 'color', 'platforms'],
-    }).waitTask()
-    await gamesIndex.updateSettings({
-      filterableAttributes: ['genres', 'color', 'platforms'],
-    }).waitTask()
+    await moviesIndex
+      .updateSettings({
+        filterableAttributes: ['genres', 'color', 'platforms'],
+      })
+      .waitTask()
+    await gamesIndex
+      .updateSettings({
+        filterableAttributes: ['genres', 'color', 'platforms'],
+      })
+      .waitTask()
 
     await moviesIndex.addDocuments(movies).waitTask()
     await gamesIndex.addDocuments(games).waitTask()

--- a/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/multi-index-search.test.ts
@@ -14,15 +14,13 @@ describe('Multi-index search test', () => {
 
     await moviesIndex.updateSettings({
       filterableAttributes: ['genres', 'color', 'platforms'],
-    })
+    }).waitTask()
     await gamesIndex.updateSettings({
       filterableAttributes: ['genres', 'color', 'platforms'],
-    })
+    }).waitTask()
 
-    await moviesIndex.addDocuments(movies)
-    const response = await gamesIndex.addDocuments(games)
-
-    await meilisearchClient.waitForTask(response.taskUid)
+    await moviesIndex.addDocuments(movies).waitTask()
+    await gamesIndex.addDocuments(games).waitTask()
   })
 
   test('searching on two indexes', async () => {

--- a/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
+++ b/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
@@ -5,10 +5,7 @@ import { dataset, meilisearchClient, type Movies } from './assets/utils.js'
 describe('InstantMeiliSearch overridden parameters', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('instantiating with, and changing overridden Meilisearch parameters', async () => {

--- a/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
+++ b/packages/instant-meilisearch/__tests__/overridden-meilisearch-parameters.test.ts
@@ -4,12 +4,11 @@ import { dataset, meilisearchClient, type Movies } from './assets/utils.js'
 
 describe('InstantMeiliSearch overridden parameters', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
-    const documentsTask = await meilisearchClient
+    await meilisearchClient.deleteIndex('movies').waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('instantiating with, and changing overridden Meilisearch parameters', async () => {

--- a/packages/instant-meilisearch/__tests__/pagination.test.ts
+++ b/packages/instant-meilisearch/__tests__/pagination.test.ts
@@ -8,15 +8,15 @@ import {
 
 describe('Pagination browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('1 hitsPerPage', async () => {

--- a/packages/instant-meilisearch/__tests__/pagination.test.ts
+++ b/packages/instant-meilisearch/__tests__/pagination.test.ts
@@ -13,10 +13,7 @@ describe('Pagination browser test', () => {
       .index('movies')
       .updateFilterableAttributes(['genres'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('1 hitsPerPage', async () => {

--- a/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
@@ -4,15 +4,15 @@ import { dataset, type Movies, meilisearchClient } from './assets/utils.js'
 
 describe('Pagination browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('placeholdersearch set to true', async () => {

--- a/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
+++ b/packages/instant-meilisearch/__tests__/placeholder-search.test.ts
@@ -9,10 +9,7 @@ describe('Pagination browser test', () => {
       .index('movies')
       .updateFilterableAttributes(['genres'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('placeholdersearch set to true', async () => {

--- a/packages/instant-meilisearch/__tests__/snippets.test.ts
+++ b/packages/instant-meilisearch/__tests__/snippets.test.ts
@@ -13,10 +13,7 @@ describe('Snippet Browser test', () => {
       .index('movies')
       .updateFilterableAttributes(['genres'])
       .waitTask()
-    await meilisearchClient
-      .index('movies')
-      .addDocuments(dataset)
-      .waitTask()
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('Test one attributesToSnippet on placeholder without a snippetEllipsisText', async () => {

--- a/packages/instant-meilisearch/__tests__/snippets.test.ts
+++ b/packages/instant-meilisearch/__tests__/snippets.test.ts
@@ -8,15 +8,15 @@ import {
 
 describe('Snippet Browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient
       .index('movies')
       .updateFilterableAttributes(['genres'])
-    const documentsTask = await meilisearchClient
+      .waitTask()
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('Test one attributesToSnippet on placeholder without a snippetEllipsisText', async () => {

--- a/packages/instant-meilisearch/__tests__/sort.test.ts
+++ b/packages/instant-meilisearch/__tests__/sort.test.ts
@@ -11,14 +11,14 @@ import { splitSortString } from '../src/contexts/sort-context.js'
 describe('Sort browser test', () => {
   beforeAll(async () => {
     await meilisearchClient.deleteIndex('movies').waitTask()
-    await meilisearchClient.index('movies').updateSettings({
-      sortableAttributes: ['release_date', 'title'],
-    }).waitTask()
-
     await meilisearchClient
       .index('movies')
-      .addDocuments(dataset)
+      .updateSettings({
+        sortableAttributes: ['release_date', 'title'],
+      })
       .waitTask()
+
+    await meilisearchClient.index('movies').addDocuments(dataset).waitTask()
   })
 
   test('sort-by one field', async () => {

--- a/packages/instant-meilisearch/__tests__/sort.test.ts
+++ b/packages/instant-meilisearch/__tests__/sort.test.ts
@@ -10,16 +10,15 @@ import { splitSortString } from '../src/contexts/sort-context.js'
 
 describe('Sort browser test', () => {
   beforeAll(async () => {
-    const deleteTask = await meilisearchClient.deleteIndex('movies')
-    await meilisearchClient.waitForTask(deleteTask.taskUid)
+    await meilisearchClient.deleteIndex('movies').waitTask()
     await meilisearchClient.index('movies').updateSettings({
       sortableAttributes: ['release_date', 'title'],
-    })
+    }).waitTask()
 
-    const documentsTask = await meilisearchClient
+    await meilisearchClient
       .index('movies')
       .addDocuments(dataset)
-    await meilisearchClient.index('movies').waitForTask(documentsTask.taskUid)
+      .waitTask()
   })
 
   test('sort-by one field', async () => {

--- a/packages/instant-meilisearch/package.json
+++ b/packages/instant-meilisearch/package.json
@@ -44,7 +44,7 @@
     "templates"
   ],
   "dependencies": {
-    "meilisearch": "^0.49.0"
+    "meilisearch": "0.50"
   },
   "devDependencies": {
     "cssnano": "^4.1.10",

--- a/packages/instant-meilisearch/src/client/config/index.ts
+++ b/packages/instant-meilisearch/src/client/config/index.ts
@@ -61,7 +61,7 @@ export function validateInstantMeiliSearchParams(
   apiKey: string | (() => string),
   instantMeiliSearchOptions: InstantMeiliSearchOptions
 ) {
-  const { requestConfig, httpClient } = instantMeiliSearchOptions
+  const { requestInit, httpClient } = instantMeiliSearchOptions
   // Validate host url
   if (typeof hostUrl !== 'string') {
     throw new TypeError(
@@ -76,9 +76,9 @@ export function validateInstantMeiliSearchParams(
     )
   }
 
-  // Validate requestConfig
-  if (requestConfig !== undefined && !isPureObject(requestConfig)) {
-    throw new TypeError('Provided requestConfig should be an object')
+  // Validate requestInit
+  if (requestInit !== undefined && !isPureObject(requestInit)) {
+    throw new TypeError('Provided requestInit should be an object')
   }
 
   // Validate custom HTTP client

--- a/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
+++ b/packages/instant-meilisearch/src/client/instant-meilisearch-client.ts
@@ -68,8 +68,8 @@ export function instantMeiliSearch(
     meilisearchConfig.httpClient = instantMeiliSearchOptions.httpClient
   }
 
-  if (instantMeiliSearchOptions.requestConfig !== undefined) {
-    meilisearchConfig.requestConfig = instantMeiliSearchOptions.requestConfig
+  if (instantMeiliSearchOptions.requestInit !== undefined) {
+    meilisearchConfig.requestInit = instantMeiliSearchOptions.requestInit
   }
 
   const meilisearchClient = new MeiliSearch(meilisearchConfig)

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -71,7 +71,7 @@ type BaseInstantMeiliSearchOptions = {
 
 export type InstantMeiliSearchOptions = Pick<
   MeilisearchConfig,
-  'requestConfig' | 'httpClient'
+  'requestInit' | 'httpClient'
 > &
   BaseInstantMeiliSearchOptions
 

--- a/playgrounds/autocomplete/setup.mjs
+++ b/playgrounds/autocomplete/setup.mjs
@@ -6,5 +6,4 @@ const client = new MeiliSearch({
   apiKey: 'masterKey',
 })
 await client.index('steam-video-games').delete()
-const task = await client.index('steam-video-games').addDocuments(games)
-await client.waitForTask(task.taskUid)
+client.index('steam-video-games').addDocuments(games).waitTask()

--- a/playgrounds/local-react/setup.mjs
+++ b/playgrounds/local-react/setup.mjs
@@ -22,11 +22,8 @@ await gamesIndex.updateSettings({
   sortableAttributes: ['recommendationCount'],
 })
 
-const moviesTask = await moviesIndex.addDocuments(movies)
-const gamesTask = await gamesIndex.addDocuments(games)
-
-await moviesTask.waitTask()
-await gamesTask.waitTask()
+const moviesTask = await moviesIndex.addDocuments(movies).waitTask()
+const gamesTask = await gamesIndex.addDocuments(games).waitTask()
 
 console.log(moviesTask)
 console.log(gamesTask)

--- a/playgrounds/local-react/setup.mjs
+++ b/playgrounds/local-react/setup.mjs
@@ -22,10 +22,11 @@ await gamesIndex.updateSettings({
   sortableAttributes: ['recommendationCount'],
 })
 
-const moviesRes = await moviesIndex.addDocuments(movies)
-const gamesRes = await gamesIndex.addDocuments(games)
+const moviesTask = await moviesIndex.addDocuments(movies)
+const gamesTask = await gamesIndex.addDocuments(games)
 
-const moviesTask = await client.waitForTask(moviesRes.taskUid)
-const gamesTask = await client.waitForTask(gamesRes.taskUid)
+await moviesTask.waitTask()
+await gamesTask.waitTask()
+
 console.log(moviesTask)
 console.log(gamesTask)

--- a/playgrounds/node-env/index.js
+++ b/playgrounds/node-env/index.js
@@ -12,8 +12,7 @@ const msClient = new MeiliSearch({
 })
 
 try {
-  const task1 = await msClient.index('node_test').addDocuments([])
-  await msClient.waitForTask(task1.taskUid)
+  await msClient.index('node_test').addDocuments([]).waitTask()
   await searchClient.search([
     {
       indexName: 'node_test',
@@ -23,8 +22,7 @@ try {
     },
   ])
 
-  const task2 = await msClient.index('node_test').delete()
-  await msClient.waitForTask(task2.taskUid)
+  await msClient.index('node_test').delete().waitTask()
   process.exit(0)
 } catch (e) {
   console.log(e)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4683,10 +4683,10 @@ mdn-data@2.0.4:
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-meilisearch@^0.49.0:
-  version "0.49.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.49.0.tgz#21584739588cd33cc970e1abbcb4d6240e6928d6"
-  integrity sha512-oMJ/e6Or6cz2+owcEKeB11p2OWiWW9NmssqOZC/KIwQB0sBGKLJ7RCpYzf+GhUIZIZ9FRYZ419ox3RGebVQX5g==
+meilisearch@0.50:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.50.0.tgz#b2eb92984100f33fe2c5dc19600bdc643776170e"
+  integrity sha512-9IzIkobvnuS18Eg4dq/eJB9W+eXqeLZjNRgq/kKMswSmVYYSQsXqGgSuCA0JkF+o5RwJlwIsieQee6rh313VhA==
 
 meow@^6.0.0:
   version "6.1.1"


### PR DESCRIPTION
# Pull Request

## Related issue

Following https://github.com/meilisearch/integration-guides/issues/315

## What does this PR do?
- Bump `meilisearch-js` dependency to v0.50

Thank you so much for contributing to Meilisearch!
