### PR TITLE
Fix search client type

### DIFF
--- a/.changeset/weak-chefs-share.md
+++ b/.changeset/weak-chefs-share.md
@@ -1,0 +1,5 @@
+---
+"@meilisearch/instant-meilisearch": patch
+---
+
+Fix search client type

--- a/packages/instant-meilisearch/src/types/types.ts
+++ b/packages/instant-meilisearch/src/types/types.ts
@@ -1,8 +1,8 @@
-import type SearchClient from 'instantsearch.js'
 import type {
   MultipleQueriesQuery as AlgoliaMultipleQueriesQuery,
   multipleSearchForFacetValues,
 } from '@algolia/client-search'
+import type { InstantSearchOptions } from 'instantsearch.js/es/lib/InstantSearch.js'
 import type {
   MultiSearchQuery as MeiliSearchMultiSearchParams,
   MultiSearchResult,
@@ -127,9 +127,10 @@ export type InstantSearchGeoParams = {
   insidePolygon?: ReadonlyArray<readonly number[]>
 }
 
-export type InstantMeiliSearchInstance = ReturnType<typeof SearchClient> & {
-  clearCache: () => void
-}
+export type InstantMeiliSearchInstance =
+  InstantSearchOptions['searchClient'] & {
+    clearCache: () => void
+  }
 
 export type InstantMeiliSearchObject = {
   meiliSearchInstance: MeiliSearch


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1377

## What does this PR do?
Use `InstantSearchOptions['searchClient']` to define the search client type, similar to how [instantsearch.js does it](https://github.com/algolia/instantsearch/blob/4170d7c9a3ee4adc729330a7cba90527aca2dbc5/packages/instantsearch.js/src/lib/InstantSearch.ts#L215). This fixes the issue where search client won't match the type required by react instantsearch.
I'm not too happy with the import from `instantsearch.js/es/lib/InstantSearch.js`. InstantSearch (and `InstantSearchOptions`) should actually be exported by the root types of `instantsearch.js`, but I assume there's either something wrong with their package definition or the vite/ts config in this repo, but I'm honestly not too proficient with bundling configs.
I also saw (after implementing this) that this is also done similarly in #1378. But I hope we can merge this one more quickly, as it's just a tiny change.


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the type definition for the search client to ensure improved type accuracy.

* **Chores**
  * Added a changeset to document the patch update for the type correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->