### PR TITLE
Upgrade readme & changelog to reflect change from requestConfig to requestInit

### DIFF
--- a/packages/instant-meilisearch/CHANGELOG.md
+++ b/packages/instant-meilisearch/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Minor Changes
 
 - 3085de3: Bump meilisearch to v0.50.0
+  - This change has a breaking change in Meilisearch dependency, where the Meilisearch class parameter `requestConfig` has been changed to `requestInit`
 
 ## 0.25.0
 

--- a/packages/instant-meilisearch/README.md
+++ b/packages/instant-meilisearch/README.md
@@ -157,7 +157,7 @@ where `searchClient` is to be passed to instantsearch.js or its many framework a
 - [`finitePagination`](#finite-pagination): Enable finite pagination when using the [`pagination`](#-pagination) widget (default: `false`) .
 - [`primaryKey`](#primary-key): Specify the primary key of your documents (default `undefined`).
 - [`keepZeroFacets`](#keep-zero-facets): Show the facets value even when they have 0 matches (default `false`).
-- [`requestConfig`](#request-config): Use custom request configurations.
+- [`requestInit`](#request-config): Use custom request configurations.
 - [`httpClient`](#custom-http-client): Use a custom HTTP client.
 - [`meiliSearchParams`](#meilisearch-search-parameters): Override a selection of Meilisearch search parameters (default `undefined`).
 
@@ -238,7 +238,7 @@ for example, with custom headers.
 
 ```ts
 {
-  requestConfig: {
+  requestInit: {
     headers: {
       Authorization: AUTH_TOKEN
     },


### PR DESCRIPTION
In Meilisearch v0.50.0: 

> The Meilisearch class now accepts a requestInit parameter instead of requestConfig. Parameters of requestInit are the same, except it no longer accepts signal.

Details here: https://github.com/meilisearch/meilisearch-js/releases

This package needs to update readme